### PR TITLE
LT募集終了

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,8 +31,7 @@
     </div>
     <h3>LT への応募</h3>
     <div class="registration_external">
-      LT発表を募集しております。ご希望の方は <strong><a href="https://docs.google.com/forms/d/1LFVIe4N81CFsrhyCIPJNts7ZLZgprdjg_gq6jWyvfDY/">応募フォーム</a></strong> からご応募ください。<br>
-      締切は6月14日(木)23:59(JST)です。
+      LTの募集は締め切りました。ご応募いただいた皆様ありがとうございました！
     </div>
     <hr>
     <h3>参加登録</h3>


### PR DESCRIPTION
LT募集フォームへのリンクを削除し、LT募集は終了したという告知に書き換えました。