### PR TITLE
LTリストが発表順でないことがわかり易くする

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
       <hr>
       <h3>開催日時</h3>
       <ul>
-        <li>2018年07月29日(日曜日) 14:00-19:30(予定)
+        <li>2018年07月29日(日曜日) 13:30開場/14:00-19:30(予定)
           <ul><li>「なんと! 肉の日」です。</li>
           </ul>
         </li>
@@ -90,9 +90,11 @@
       </ul>
       <hr>
       <h3 id="schedule">スケジュール</h3>
-      <p>タイムテーブルや発表順はただ今<b>検討中</b>です。<br />以下の発表内容を予定しています。</p>
+      <p><span style="color: red">タイムテーブルや発表順はただ今検討中です。</span>決まり次第掲載します。</p>
       <!-- <p>(イベントの性質上、進行状況により時間が前後する場合がございます。ご了承下さい）</p> -->
-      <div style="margin-left: 50px;">
+      <h3 id="talks">発表予定のLT</h3>
+      <p>以下の発表内容を予定しています。</p>
+      <div style="margin-left: 20px;">
         <ul style="list-style-type: disc">
           <li>イチロー #とは ,をPython...じゃなくてRubyで分析する - shinyorke（野球エンジニア）</li>
           <li>Make Your Ruby Script Confusing - tagomoris</li>


### PR DESCRIPTION
LTリストが発表順に並んでいると誤解を呼んでいるので、改善しました。

- タイムテーブル未定を赤字で目立たせた
- LTリストの独立セクション「発表予定のLT」を作った
  - 変更前は「スケジュール」セクション内にあった

ついでに書き忘れていた開場予定時間を追記
